### PR TITLE
Add named export for TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,3 @@
-export = EventEmitter;
-
-declare namespace EventEmitter {
-  export interface ListenerFn {
-    (...args: Array<any>): void;
-  }
-}
-
 /**
  * Minimal `EventEmitter` interface that is molded against the Node.js
  * `EventEmitter` interface.
@@ -56,3 +48,17 @@ declare class EventEmitter {
    */
   removeAllListeners(event?: string | symbol): this;
 }
+
+declare namespace EventEmitter {
+  export interface ListenerFn {
+    (...args: Array<any>): void;
+  }
+
+  export interface EventEmitterStatic {
+    new(): EventEmitter;
+  }
+
+  export const EventEmitter: EventEmitterStatic;
+}
+
+export = EventEmitter;


### PR DESCRIPTION
This PR fixes a couple of issues with the reformatted eventemitter3 definitions:

1. Named exports now work correctly
2. Rearranged the class & namespace declarations as mentioned in [the docs](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#merging-namespaces-with-classes-functions-and-enums).

I've also updated my test repository to work with the updates. You can play around with it [here](https://github.com/delta62/ee3-ts-example) if you want.

Cheers!